### PR TITLE
Added Controls enum to remove all vc configuration from App delegate

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06B23C31220DB76D00ADEF72 /* ContentControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B23C30220DB76D00ADEF72 /* ContentControls.swift */; };
+		06B23C33220DB77600ADEF72 /* AdControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B23C32220DB77600ADEF72 /* AdControls.swift */; };
+		06B23C35220DBB6E00ADEF72 /* Controls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06B23C34220DBB6E00ADEF72 /* Controls.swift */; };
 		DEE135021F0FD2F100C47354 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE135011F0FD2F100C47354 /* AppDelegate.swift */; };
 		DEE135091F0FD2F100C47354 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DEE135081F0FD2F100C47354 /* Assets.xcassets */; };
 		DEE1350C1F0FD2F100C47354 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DEE1350A1F0FD2F100C47354 /* LaunchScreen.storyboard */; };
@@ -29,6 +32,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		06B23C30220DB76D00ADEF72 /* ContentControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentControls.swift; sourceTree = "<group>"; };
+		06B23C32220DB77600ADEF72 /* AdControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdControls.swift; sourceTree = "<group>"; };
+		06B23C34220DBB6E00ADEF72 /* Controls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controls.swift; sourceTree = "<group>"; };
 		DEE134FE1F0FD2F100C47354 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DEE135011F0FD2F100C47354 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DEE135081F0FD2F100C47354 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -71,6 +77,9 @@
 			children = (
 				DEE135011F0FD2F100C47354 /* AppDelegate.swift */,
 				DEE135081F0FD2F100C47354 /* Assets.xcassets */,
+				06B23C32220DB77600ADEF72 /* AdControls.swift */,
+				06B23C30220DB76D00ADEF72 /* ContentControls.swift */,
+				06B23C34220DBB6E00ADEF72 /* Controls.swift */,
 				DEE1350A1F0FD2F100C47354 /* LaunchScreen.storyboard */,
 				DEE1350D1F0FD2F100C47354 /* Info.plist */,
 			);
@@ -106,7 +115,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0900;
 				LastUpgradeCheck = 0940;
-				ORGANIZATIONNAME = "One by AOL : Publishers";
+				ORGANIZATIONNAME = "Oath Inc.";
 				TargetAttributes = {
 					DEE134FD1F0FD2F100C47354 = {
 						CreatedOnToolsVersion = 9.0;
@@ -149,7 +158,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				06B23C35220DBB6E00ADEF72 /* Controls.swift in Sources */,
+				06B23C33220DB77600ADEF72 /* AdControls.swift in Sources */,
 				DEE135021F0FD2F100C47354 /* AppDelegate.swift in Sources */,
+				06B23C31220DB76D00ADEF72 /* ContentControls.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -284,7 +296,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 7FCMSU478D;
+				DEVELOPMENT_TEAM = 7V23547MMU;
 				INFOPLIST_FILE = Demo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -299,7 +311,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 7FCMSU478D;
+				DEVELOPMENT_TEAM = 7V23547MMU;
 				INFOPLIST_FILE = Demo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Demo/Demo/AdControls.swift
+++ b/Demo/Demo/AdControls.swift
@@ -1,0 +1,21 @@
+//  Copyright 2019, Oath Inc.
+//  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
+
+import PlayerControls
+
+extension Controls {
+    static let ad: AdVideoControls = {
+        let vc = AdVideoControls()
+        vc.view.backgroundColor = .red
+        vc.view.tintColor = .blue
+        vc.props = .init(mainAction: .play(.nop),
+                         seeker: AdVideoControls.Props.Seeker(
+                            remainingPlayTime: "0:30",
+                            currentValue: 0,
+                            accessibilityLabel: ""),
+                         click: .nop,
+                         isLoading: false,
+                         airplayActiveViewHidden: true)
+        return vc
+    }()
+}

--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -4,66 +4,6 @@
 import UIKit
 import PlayerControls
 
-typealias Props = ContentControlsViewController.Props
-
-func props(progress: ContentControlsViewController.Props.Progress = 0) -> Props {
-    func backgroundColor() {
-        guard let view = UIApplication.shared.windows.first?.rootViewController?.view else { return }
-        switch view.backgroundColor {
-        case UIColor.red?:
-            view.backgroundColor = .blue
-            view.tintColor = .red
-        case UIColor.blue?:
-            view.backgroundColor = .red
-            view.tintColor = .blue
-        default:
-            break
-        }
-    }
-    return Props.player(Props.Player(
-        playlist: Props.Playlist(
-            next: .nop,
-            prev: .nop),
-        item: .playable(Props.Controls(
-            airplay: .enabled,
-            audible: Props.MediaGroupControl(options: []),
-            camera: Props.Camera(
-                angles: Props.Angles(
-                    horizontal: 0.0,
-                    vertical: 0.0),
-                moveTo: .nop),
-            error: nil,
-            legible: Props.MediaGroupControl(options: []),
-            live: Props.Live(
-                isHidden: true,
-                dotColor: nil),
-            loading: false,
-            pictureInPictureControl: .possible(.nop),
-            playbackAction: .play(.nop),
-            seekbar: Props.Seekbar(
-                duration: 3600,
-                currentTime: 1800,
-                progress: progress,
-                buffered: 1,
-                seeker: Props.Seeker(
-                    cuePoints: [0, 0.5, 0.9, 1],
-                    seekTo: .nop,
-                    state: Props.State(
-                        start: .nop,
-                        update: .nop,
-                        stop: .nop))),
-            settings: .enabled(.nop),
-            sideBarViewHidden: false,
-            thumbnail: nil,
-            title: "Title",
-            animationsEnabled: true,
-            contentFullScreen: .init(action: backgroundColor),
-            brandedContent: Props.BrandedContent {
-                $0.advertisementText = "Short text"
-                $0.action = .nop
-        }))))
-}
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
@@ -71,80 +11,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
-        let vc = DefaultControlsViewController()
-        vc.view.backgroundColor = .red
-        vc.view.tintColor = .blue
-        vc.props = props()
-        vc.sidebarProps = sideProps()
-        
-        if #available(iOS 10.0, *) {
-            var progress: CGFloat = 0.0
-            Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true) { (timer) in
-                if vc.props.player?.item.playable?.seekbar?.progress.value == 1.0  {
-                    progress = 0
-                }
-                progress += 0.01
-                vc.props = props(progress: ContentControlsViewController.Props.Progress(progress))
-            }
-        }
-        
         window = UIWindow(frame: UIScreen.main.bounds)
-        window?.rootViewController = vc
+        window?.rootViewController = Controls.content
         window?.makeKeyAndVisible()
         
         return true
     }
 }
 
-func sideProps() -> [SideBarView.ButtonProps]{
-    
-    let shareIcons = SideBarView.ButtonProps.Icons(
-        normal: UIImage(named: "icon-share", in: Bundle(for: SideBarView.self), compatibleWith: nil)!,
-        selected: nil,
-        highlighted: UIImage(named: "icon-share-active", in: Bundle(for: SideBarView.self), compatibleWith: nil))
-    
-    let share = SideBarView.ButtonProps(
-        isEnabled: true,
-        isSelected: false,
-        icons: shareIcons,
-        handler: .nop,
-        accessibility: SideBarView.ButtonProps.Accessibility.empty)
-    
-    let addIcon = SideBarView.ButtonProps.Icons(
-        normal: UIImage(named: "icon-add", in: Bundle(for: SideBarView.self), compatibleWith: nil)!,
-        selected: nil,
-        highlighted: UIImage(named: "icon-add-active", in: Bundle(for: SideBarView.self), compatibleWith: nil))
-    
-    let add = SideBarView.ButtonProps(
-        isEnabled: true,
-        isSelected: false,
-        icons: addIcon,
-        handler: .nop,
-        accessibility: SideBarView.ButtonProps.Accessibility.empty)
-    
-    let favoriteIcon = SideBarView.ButtonProps.Icons(
-        normal: UIImage(named: "icon-fav", in: Bundle(for: SideBarView.self), compatibleWith: nil)!,
-        selected: nil,
-        highlighted: UIImage(named: "icon-fav-active", in: Bundle(for: SideBarView.self), compatibleWith: nil))
-    
-    let favorite = SideBarView.ButtonProps(
-        isEnabled: true,
-        isSelected: false,
-        icons: favoriteIcon,
-        handler: .nop,
-        accessibility: SideBarView.ButtonProps.Accessibility.empty)
-    
-    let laterIcon = SideBarView.ButtonProps.Icons(
-        normal: UIImage(named: "icon-later", in: Bundle(for: SideBarView.self), compatibleWith: nil)!,
-        selected: nil,
-        highlighted: UIImage(named: "icon-later-active", in: Bundle(for: SideBarView.self), compatibleWith: nil))
-    
-    let later = SideBarView.ButtonProps(
-        isEnabled: true,
-        isSelected: false,
-        icons: laterIcon,
-        handler: .nop,
-        accessibility: SideBarView.ButtonProps.Accessibility.empty)
-    
-    return [later, favorite, share, add]
-}

--- a/Demo/Demo/ContentControls.swift
+++ b/Demo/Demo/ContentControls.swift
@@ -1,0 +1,141 @@
+//  Copyright 2019, Oath Inc.
+//  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
+
+import PlayerControls
+
+typealias Props = ContentControlsViewController.Props
+
+extension Controls {
+    static let content: ContentControlsViewController = {
+        let vc = DefaultControlsViewController()
+        vc.props = contentProps()
+        vc.sidebarProps = sideBarProps
+        vc.view.backgroundColor = .red
+        vc.view.tintColor = .blue
+        if #available(iOS 10.0, *) {
+            var progress: CGFloat = 0.0
+            Foundation.Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true) { (timer) in
+                if vc.props.player?.item.playable?.seekbar?.progress.value == 1.0  {
+                    progress = 0
+                }
+                progress += 0.01
+                vc.props = contentProps(progress: ContentControlsViewController.Props.Progress(progress))
+            }
+        }
+        return vc
+    }()
+    
+    private static func contentProps(progress: Props.Progress = 0) -> Props {
+        func backgroundColor() {
+            guard let view = UIApplication.shared.windows.first?.rootViewController?.view else { return }
+            switch view.backgroundColor {
+            case UIColor.red?:
+                view.backgroundColor = .blue
+                view.tintColor = .red
+            case UIColor.blue?:
+                view.backgroundColor = .red
+                view.tintColor = .blue
+            default:
+                break
+            }
+        }
+        
+        return Props.player(Props.Player(
+            playlist: Props.Playlist(
+                next: .nop,
+                prev: .nop),
+            item: .playable(Props.Controls(
+                airplay: .enabled,
+                audible: Props.MediaGroupControl(options: []),
+                camera: Props.Camera(
+                    angles: Props.Angles(
+                        horizontal: 0.0,
+                        vertical: 0.0),
+                    moveTo: .nop),
+                error: nil,
+                legible: Props.MediaGroupControl(options: []),
+                live: Props.Live(
+                    isHidden: true,
+                    dotColor: nil),
+                loading: false,
+                pictureInPictureControl: .possible(.nop),
+                playbackAction: .play(.nop),
+                seekbar: Props.Seekbar(
+                    duration: 3600,
+                    currentTime: 1800,
+                    progress: progress,
+                    buffered: 1,
+                    seeker: Props.Seeker(
+                        cuePoints: [0, 0.5, 0.9, 1],
+                        seekTo: .nop,
+                        state: Props.State(
+                            start: .nop,
+                            update: .nop,
+                            stop: .nop))),
+                settings: .enabled(.nop),
+                sideBarViewHidden: false,
+                thumbnail: nil,
+                title: "Title",
+                animationsEnabled: true,
+                contentFullScreen: .init(action: backgroundColor),
+                brandedContent: Props.BrandedContent {
+                    $0.advertisementText = "Short text"
+                    $0.action = .nop
+            }))
+        ))
+    }
+    
+    
+    private static let sideBarProps: [SideBarView.ButtonProps] = {
+        
+        let shareIcons = SideBarView.ButtonProps.Icons(
+            normal: UIImage(named: "icon-share", in: Bundle(for: SideBarView.self), compatibleWith: nil)!,
+            selected: nil,
+            highlighted: UIImage(named: "icon-share-active", in: Bundle(for: SideBarView.self), compatibleWith: nil))
+        
+        let share = SideBarView.ButtonProps(
+            isEnabled: true,
+            isSelected: false,
+            icons: shareIcons,
+            handler: .nop,
+            accessibility: SideBarView.ButtonProps.Accessibility.empty)
+        
+        let addIcon = SideBarView.ButtonProps.Icons(
+            normal: UIImage(named: "icon-add", in: Bundle(for: SideBarView.self), compatibleWith: nil)!,
+            selected: nil,
+            highlighted: UIImage(named: "icon-add-active", in: Bundle(for: SideBarView.self), compatibleWith: nil))
+        
+        let add = SideBarView.ButtonProps(
+            isEnabled: true,
+            isSelected: false,
+            icons: addIcon,
+            handler: .nop,
+            accessibility: SideBarView.ButtonProps.Accessibility.empty)
+        
+        let favoriteIcon = SideBarView.ButtonProps.Icons(
+            normal: UIImage(named: "icon-fav", in: Bundle(for: SideBarView.self), compatibleWith: nil)!,
+            selected: nil,
+            highlighted: UIImage(named: "icon-fav-active", in: Bundle(for: SideBarView.self), compatibleWith: nil))
+        
+        let favorite = SideBarView.ButtonProps(
+            isEnabled: true,
+            isSelected: false,
+            icons: favoriteIcon,
+            handler: .nop,
+            accessibility: SideBarView.ButtonProps.Accessibility.empty)
+        
+        let laterIcon = SideBarView.ButtonProps.Icons(
+            normal: UIImage(named: "icon-later", in: Bundle(for: SideBarView.self), compatibleWith: nil)!,
+            selected: nil,
+            highlighted: UIImage(named: "icon-later-active", in: Bundle(for: SideBarView.self), compatibleWith: nil))
+        
+        let later = SideBarView.ButtonProps(
+            isEnabled: true,
+            isSelected: false,
+            icons: laterIcon,
+            handler: .nop,
+            accessibility: SideBarView.ButtonProps.Accessibility.empty)
+        
+        return [later, favorite, share, add]
+    }()
+}

--- a/Demo/Demo/Controls.swift
+++ b/Demo/Demo/Controls.swift
@@ -1,0 +1,6 @@
+//  Copyright 2019, Oath Inc.
+//  Licensed under the terms of the MIT License. See LICENSE.md file in project root for terms.
+
+import PlayerControls
+
+enum Controls {}

--- a/PlayerControls/PlayerControls.xcodeproj/project.pbxproj
+++ b/PlayerControls/PlayerControls.xcodeproj/project.pbxproj
@@ -408,7 +408,7 @@
 				TargetAttributes = {
 					50582F5A1E65C41900B18908 = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = 7FCMSU478D;
+						DevelopmentTeam = 7V23547MMU;
 						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 					};
@@ -638,7 +638,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 7FCMSU478D;
+				DEVELOPMENT_TEAM = 7V23547MMU;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -657,7 +657,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 7FCMSU478D;
+				DEVELOPMENT_TEAM = 7V23547MMU;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/SnapshotTests/SnapshotTests.xcodeproj/project.pbxproj
+++ b/SnapshotTests/SnapshotTests.xcodeproj/project.pbxproj
@@ -446,7 +446,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 95F456P57Y;
+				DEVELOPMENT_TEAM = KYF8QFK3G9;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -467,7 +467,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 95F456P57Y;
+				DEVELOPMENT_TEAM = KYF8QFK3G9;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",


### PR DESCRIPTION
<!-- Please describe all the changes that were done in this PR. -->
## Changes
- It is now easier to select Controls ViewController for ad or content from AppDelegate

@VerizonAdPlatforms/mobile-sdk-developers: Please review.
