### PR TITLE
Fixed AccessibilityTraits that caused crash on Swift 4.0

### DIFF
--- a/PlayerControls/sources/SideBarView.swift
+++ b/PlayerControls/sources/SideBarView.swift
@@ -55,8 +55,11 @@ public final class SideBarView: UIView {
             public var label: String?
             /// Corresponds to UIButton 'accessibilityHint' property.
             public var hint: String?
-            /// Corresponds to UIButton 'accessibilityTraits' property.
-            public var traits: UIAccessibilityTraits = UIAccessibilityTraits.button
+            
+            public init(label: String? = nil, hint: String? = nil) {
+                self.label = label
+                self.hint = hint
+            }
         }
         
         /// Touch handler for button.
@@ -135,7 +138,7 @@ public final class SideBarView: UIView {
                 button.setImage(prop.icons.highlighted, for: .highlighted)
                 button.accessibilityLabel = prop.accessibility.label
                 button.accessibilityHint = prop.accessibility.hint
-                button.accessibilityTraits = prop.accessibility.traits
+                button.accessibilityTraits = UIAccessibilityTraits.button
                 button.sizeToFit()
             } else {
                 remove(button: button)


### PR DESCRIPTION
## Changes
- Dropped `traits` property from `Accessibility` struct. Now the `acessibilityTraits` property will always be `button`. 
- Used constructor instead of `static var` to fix an issue on Swift 4.0.
- Added `public init` for `Accessibility` struct because before it was internal and customers were not able to set an accessibility for their buttons

@VerizonAdPlatforms/mobile-sdk-developers: Please review.
